### PR TITLE
BBS-25: implemented delete API for ticket

### DIFF
--- a/src/main/java/com/java/busbookingsystem/ticket/controller/TicketController.java
+++ b/src/main/java/com/java/busbookingsystem/ticket/controller/TicketController.java
@@ -53,6 +53,15 @@ public  class TicketController {
 
     }
 
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasAnyAuthority('ADMIN','USER')")
+    public ResponseEntity<RestResponse> delete(@PathVariable long id) {
+        String message = ticketService.deleteById(id);
+        return RestHelper.responseMessage(message);
+    }
+
+
+
 
 
 

--- a/src/main/java/com/java/busbookingsystem/ticket/model/Ticket.java
+++ b/src/main/java/com/java/busbookingsystem/ticket/model/Ticket.java
@@ -41,8 +41,6 @@ public class Ticket {
         this.user = user;
     }
 
-    public User getUser() {
-        return user;
-    }
+
 }
     

--- a/src/main/java/com/java/busbookingsystem/ticket/service/TicketService.java
+++ b/src/main/java/com/java/busbookingsystem/ticket/service/TicketService.java
@@ -1,6 +1,7 @@
 package com.java.busbookingsystem.ticket.service;
 
 
+import com.java.busbookingsystem.bus.model.Bus;
 import com.java.busbookingsystem.ticket.Repository.TicketRepository;
 import com.java.busbookingsystem.ticket.mapper.TicketMapper;
 import com.java.busbookingsystem.ticket.model.Ticket;
@@ -8,14 +9,19 @@ import com.java.busbookingsystem.ticket.model.TicketDTO;
 import com.java.busbookingsystem.users.model.User;
 import com.java.busbookingsystem.users.service.UserServiceImpl;
 import com.java.busbookingsystem.utils.exception.GlobalExceptionWrapper;
+import jakarta.transaction.Transactional;
 import lombok.NonNull;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 
+import java.util.Arrays;
 import java.util.List;
 
-import static com.java.busbookingsystem.ticket.constants.TicketConstants.NOT_FOUND_MESSAGE;
-import static com.java.busbookingsystem.ticket.constants.TicketConstants.TICKET;
+import static com.java.busbookingsystem.ticket.constants.TicketConstants.*;
 
 
 @Service
@@ -51,7 +57,6 @@ public class TicketService implements ITicketService{
     }
 
 
-
     @Override
     public List<TicketDTO> findAll() {
         List<Ticket> ticket = this.ticketRepository.findAll();
@@ -59,6 +64,12 @@ public class TicketService implements ITicketService{
     }
 
 
+    @Override
+    public String deleteById(long id) {
+        Ticket ticket = findById(id);
+        ticketRepository.delete(ticket);
+        return String.format(DELETE_SUCCESSFUL);
+    }
 
 
     @Override
@@ -66,10 +77,7 @@ public class TicketService implements ITicketService{
         return "";
     }
 
-    @Override
-    public String deleteById(long id) {
-        return "";
-    }
+
 
 
 


### PR DESCRIPTION
## Description
I have implemented a DELETE API for the ticket to allow users to remove or cancel tickets from the system.

## Changes made

- [x] Added delete method in ticket service.
- [x] Added delete endpoint in ticket controller.

## API updated
Endpoint: http://localhost:8080/api/v1/ticket/3.
Method: DELETE.
Token: eyJhbGciOiJIUzI1NiJ9.eyJ0eXBlIjoiYWNjZXNzIiwic3ViIjoibGhhbW9AZ21haWwuY29tIiwiaWF0IjoxNzM1Mjg3ODI5LCJleHAiOjE3MzUyOTI4Mjl9.5fcqhYTqYt4mVqFp9lDyQ_TtFRfurclcV7RZiNZnlfo

Response:`{
    "status": true,
    "message": "Ticket details deleted successfully."
}`
